### PR TITLE
added install:extension to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:labextension": "rimraf maap_help_jupyter_extension/labextension",
     "clean:all": "jlpm clean:lib && jlpm clean:labextension",
+    "install:extension": "jlpm build",
     "start": "jupyter lab --config tests/jupyter_server_test_config.py",
     "test": "jlpm playwright test",
     "test:ui": "jlpm playwright test --ui",


### PR DESCRIPTION
Added `"install:extension": "jlpm build",` to the package.json because pyproject.toml has `build_cmd = "install:extension"` and building was failing, but adding this line to the package.json worked 
Adding this line also makes maap help consistent with the other extensions 